### PR TITLE
Additional Macros and Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - added filter `color` to MQTT templates to the color can be changed within a string
 
+### Changed
+
+- time now displays in log instead of just the name of the item variable
+
+### Fixed
+
+- removed some debug `print` statements that were left behind
+
 ## Version 2.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - time now displays in log instead of just the name of the item variable
+- dependency parsing now uses regex grouping to make things easier
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 - added filter `color` to MQTT templates to the color can be changed within a string
+- added `is_payload` macro so comparisons can be done quickly within templates, similar to using `{{ get_payload() == 'val' }}`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+
+### Added
+
+- added filter `color` to MQTT templates to the color can be changed within a string
+
 ## Version 2.1
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Messages are configured for the display using a simple `.yaml` configuration fil
   - [Display](#display)
     - [Parameters](#parameters)
     - [Examples](#examples)
+ - [Templating](#templating)
+    - [Macros](#macros)
+    - [Filters](#filters)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -285,7 +288,7 @@ variables:
       {{ value.state != 'unknown' }}
 ```
 
-A more advanced technique for combining data can be done through the `get_payload()` template method. Similar to the [states()](https://www.home-assistant.io/docs/configuration/templating/#states) method in Home Assistant; this allows MQTT templates to get payloads from other MQTT topics. These topics can be defined for the sole purpose of holding information for use later. The example below subscribes to 2 topics, one for geolocation and one for general home/away presence. The `mqtt_location` variable references the presence information to decide if the person is home or not before displaying the full geo location.  Any time a variable is updated that is used within other templates the downstream template will also be updated. These are found at runtime by looking for `get_payload()` method calls.
+A more advanced technique for combining data can be done through the `get_payload()` or `is_payload()` template methods. Similar to the [states()](https://www.home-assistant.io/docs/configuration/templating/#states) methods in Home Assistant; this allows MQTT templates to get payloads from other MQTT topics. These topics can be defined for the sole purpose of holding information for use later. The example below subscribes to 2 topics, one for geolocation and one for general home/away presence. The `mqtt_location` variable references the presence information to decide if the person is home or not before displaying the full geo location.  Any time a variable is updated that is used within other templates the downstream template will also be updated. These are found at runtime and displayed when debug logging is enabled.
 
 ```
 variables:
@@ -298,7 +301,7 @@ variables:
     # geolocation published from Home Assistant Companion App
     topic: homeassistant/mobile_app/person_a/geo_location
     template: >-
-    {% if get_payload('mqtt_presence') == 'home' %}
+    {% if is_payload('mqtt_presence', 'home') %}
     Person A is Home
     {% else %}
     Person A is {{ value }}
@@ -441,7 +444,7 @@ display:
         mode: rotate
         color: green
     update_template: >-
-      {{ get_payload('lights') == 'on' }}  
+      {{ is_payload('lights', 'on') }}  
 ```
 
 ## Templating
@@ -452,6 +455,8 @@ There are a handful of custom macros and filters available to use in local Jinja
 
 __get_payload__ - return the payload of a variable, or a blank string if there isn't one `{{ get_payload('custom_var_name') }}`
 
+__is_payload__ - similar to `get_payload` but this will evaluate against an expected value and return True/False. `{{ is_payload('var_name', 'on') }}` is the same as `{{ get_payload('var_name') == 'on' }}`
+
 __now__ - returns a Python datetime object that represents the current time `{{ now() }}`
 
 __timedelta__ - returns a Python timedelta object `{{ now() + timedelta(minutes=30) }}`
@@ -459,6 +464,8 @@ __timedelta__ - returns a Python timedelta object `{{ now() + timedelta(minutes=
 __strptime__ - uses the Python strptime function to parse a string into a datetime object `{{ strptime("January 12, 2022", "%B %d, %Y")}}`
 
 ### Filters
+
+__color__ - can be used with a template to change the color of a string within the template. Due to how the Alphasign protocol handles colors, everything after this filter will use this color until a new color code is used. This is useful for when you want the color to be based on a condition. For example `original string color until {{ 'this is red' | color('red') }}`
 
 __shorten_urls__ - finds all urls in a given string and shortens them, useful when URLs are part of text but you don't want the full string on the display. The shortened form is just the domain of the link `{{ "text with a url https://www.google.com/" | shorten_urls }}`
 

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -15,6 +15,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import alphasign
 import json
+import re
 from json.decoder import JSONDecodeError
 
 # current version
@@ -72,3 +73,12 @@ def is_json(str):
         pass
 
     return result
+
+def strip_control(str):
+    """strips Alphasign control characters from a string so it can be logged properly
+    :param str: the string to check for Alphasign control characters
+
+    :returns: the cleaned string
+    """
+
+    return re.sub("\\x1c([1-8]|[A-C])", "", str)

--- a/lib/jinja_custom.py
+++ b/lib/jinja_custom.py
@@ -15,6 +15,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import datetime
 import re
 from urllib.parse import urlparse
+from . import constants
 
 
 # global macros
@@ -55,3 +56,20 @@ def shorten_urls(value):
         value = value.replace(m[0], url.netloc)
 
     return value
+
+
+def set_color(text, color):
+    """returns the string along with the valid Alphasign color code so that strings
+    can have different colors within message templates
+
+    :params text: the text to color, first argument of a filter
+    :params color: a valid color text value, rainbow values cannot be used within Strings (per Alphasign protocol)
+
+    :returns: the text plus the valid Alphasign color code value
+    """
+
+    if(color == 'rainbow1' or color == 'rainbow2'):
+        # convert this to green as this won't work
+        color = 'green'
+
+    return f"{constants.ALPHA_COLORS[color]}{text}"

--- a/lib/manager.py
+++ b/lib/manager.py
@@ -344,6 +344,7 @@ class PayloadManager:
         # setup jinja environment - macros and filters
         self.__jinja_env = jinja2.Environment()
         self.__jinja_env.globals['get_payload'] = self.get_payload
+        self.__jinja_env.globals['is_payload'] = self.is_payload
         self.__jinja_env.globals['now'] = jinja_custom.get_date
         self.__jinja_env.globals['timedelta'] = jinja_custom.get_timedelta
         self.__jinja_env.globals['strptime'] = jinja_custom.create_time
@@ -379,6 +380,19 @@ class PayloadManager:
             result = self.__payloads[var]
 
         return result
+
+    def is_payload(self, var, expected_value):
+        """compares the given variable's payload against the expected value to return
+        either True or False, the same as doing get_payload() == "expected_value"
+
+        :param var: the MQTT variable name
+        :param expected_value: the comparison value
+
+        :returns: True if variable payload equals the expected_value, false if otherwise
+        """
+        payload = self.get_payload(var)
+        print(f"{payload}:{expected_value}")
+        return payload == expected_value
 
     def get_dependencies(self, var):
         """get any variables that uses the given variable in a template via get_payload

--- a/lib/manager.py
+++ b/lib/manager.py
@@ -193,10 +193,10 @@ class MessageManager:
                         else:
                             logging.info(f"Loading variable {aVar.get_name()}:{aVar.get_type()} for message")
                             if(aVar.get_type() == 'time'):
-                                stringObj = aVar.get_startup()
+                                stringObj = aVar.get_text()
                                 betabrite.write(stringObj.set_format(aVar.get_time_format()))  # write the time format
                                 betabrite.write(stringObj)
-                                cliText.append(colored(v, 'green'))
+                                cliText.append(colored(aVar.get_startup(), 'green'))
                             else:
                                 stringObj = alphasign.String(data=aVar.get_startup(),
                                                              label=self.__allocate_string(aVar.get_name()), size=125)

--- a/lib/manager.py
+++ b/lib/manager.py
@@ -88,7 +88,7 @@ class MessageManager:
 
         :returns: the character defined start + offset
         """
-        print(f"Creating File Label {chr(start + offset)}")
+
         return chr(start + offset)
 
     def __allocate_string(self, name):

--- a/lib/manager.py
+++ b/lib/manager.py
@@ -391,7 +391,7 @@ class PayloadManager:
         :returns: True if variable payload equals the expected_value, false if otherwise
         """
         payload = self.get_payload(var)
-        print(f"{payload}:{expected_value}")
+
         return payload == expected_value
 
     def get_dependencies(self, var):

--- a/lib/manager.py
+++ b/lib/manager.py
@@ -349,6 +349,7 @@ class PayloadManager:
         self.__jinja_env.globals['strptime'] = jinja_custom.create_time
 
         self.__jinja_env.filters['shorten_urls'] = jinja_custom.shorten_urls
+        self.__jinja_env.filters['color'] = jinja_custom.set_color
 
         # get any variable dependencies
         self.__depends = {}

--- a/lib/types/time.py
+++ b/lib/types/time.py
@@ -14,7 +14,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import alphasign
-import datetime
+from datetime import datetime
 from .. variable_type import AlphaSignVariable, PollingVariable
 
 
@@ -36,7 +36,7 @@ class DateVariable(PollingVariable):
         self.config['cron'] = '0 0 * * *'
 
     def get_text(self):
-        dateObj = datetime.datetime.today()
+        dateObj = datetime.today()
 
         return dateObj.strftime(self.config['format'])
 
@@ -70,4 +70,5 @@ class TimeVariable(AlphaSignVariable):
         return timeObj
 
     def get_startup(self):
-        return self.get_text()
+        format = "%I:%M%p" if self.get_time_format() == 0 else "%H:%M"
+        return datetime.now().strftime(format)

--- a/main.py
+++ b/main.py
@@ -113,7 +113,7 @@ def render_mqtt(var):
         newString = payload_manager.render_variable(var)
 
         # update the data on the sign
-        logging.debug(f"updated {var.get_name()}:'{colored(newString, 'green')}'")
+        logging.debug(f"updated {var.get_name()}:'{colored(constants.strip_control(newString), 'green')}'")
         update_string(var.get_name(), newString)
     else:
         logging.debug(f"update conditional not met for {var.get_name()}")


### PR DESCRIPTION
### Added

- added filter `color` to MQTT templates to the color can be changed within a string
- added `is_payload` macro so comparisons can be done quickly within templates, similar to using `{{ get_payload() == 'val' }}`

### Changed

- time now displays in log instead of just the name of the item variable
- dependency parsing now uses regex grouping to make things easier

### Fixed

- removed some debug `print` statements that were left behind