### PR TITLE
Home Assistant Text Entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## Unreleased
+
+### Added
+
+- added support for an [Home Assistant Text entity](https://www.home-assistant.io/integrations/text/) via MQTT Discovery. This exposes a variable to Home Assistant that can be updated to push text to the display. Requires HA 2022.12 or later.
+
 ## Version 2.3
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - added support for an [Home Assistant Text entity](https://www.home-assistant.io/integrations/text/) via MQTT Discovery. This exposes a variable to Home Assistant that can be updated to push text to the display. Requires HA 2022.12 or later.
 
+### Fixed
+
+- fixed some documentation regarding the use of the `color` filter
+
 ## Version 2.3
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - fixed some documentation regarding the use of the `color` filter
+- fixed [Github build status badge](https://github.com/badges/shields/issues/8671)
 
 ## Version 2.3
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ sudo pip3 install -r install/requirements.txt
 
 ### Home Assistant Entity Discovery
 
-This code can run standalone, or be further integrated with Home Assistant to show up as a light entity through the use of a [MQTT Light](https://www.home-assistant.io/integrations/light.mqtt/). This allows Home Assistant to get some run-time data and control the sign as though it was a light. For this to work MQTT#mqtt must be setup as [described below](#mqtt). In Home Assistant [MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/) is used to automatically configure the device when `--ha_discovery` is passed in at startup. Other options, like the device name, can be configured as well.
+This code can run standalone, or be further integrated with Home Assistant to expose some entities via [MQTT Light](https://www.home-assistant.io/integrations/light.mqtt/) and [MQTT Text]() integrations. This allows Home Assistant to get some run-time data, control the sign as though it was a light, and push text to the sign. For this to work MQTT must be setup as [described below](#mqtt). In Home Assistant [MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/) is used to automatically configure the device when `--ha_discovery` is passed in at startup. Other options, like the device name, can be configured as well.
 
 When MQTT is configured the program will watch for commands and publish to the following topics.
 
-* betabrite/sign/status
-* betabrite/sign/attributes
-* betabrite/sign/switch
-* betabrite/sign/available
+* betabrite/sign/status - sign off/on status
+* betabrite/sign/attributes - attributes for the Light entity
+* betabrite/sign/switch - command topic to toggle the light entity
+* betabrite/sign/available - availability topic (ie, is the program running)
+* betabrite/sign/current_text - current text entity value
+* betabrite/sign/new_text - command topic to update text entity from Home Assistant
 
-Turning the sign off and on is done via a special Text object allocated when the program starts. This is simply a blank message that pre-empts any running message at runtime to blank the display (off) and then remove it to return the display to normal messaging (on).
+Turning the sign off and on is done via a special Text object allocated when the program starts. This is simply a blank message that pre-empts any running message at runtime to blank the display (off) and then remove it to return the display to normal messaging (on). The text entity can be set in Home Assistant and used in any message through a special MQTT variable.
 
 ### Home Assistant MQTT Statestream
 
@@ -326,6 +328,21 @@ display:
       mode: hold
 ```
 
+#### Home Assistant Text Variable
+
+The Home Assistant Text Entity (setup via [Entity Discovery described above](#home-assistant-entity-discovery) is a special variable available to pull the value from the Home Assistant Text Entity. The way this works is that the entity is available to be set in Home Assistant. This can be done through a Lovelace card or through a service call. This text entry will be published via MQTT and available for use in the sign as a standard variable. It is available via the `HA_TEXT_ENTITY` variable name. Below are a few examples.
+
+```
+# add the HA Text Entity to a message
+display:
+  main:
+    - message:
+        - mqtt_location
+        - HA_TEXT_ENTITY
+      color: green
+      mode: hold
+```
+
 ## Display
 
 The display area of the `.yaml` file is where messages are setup to actually display on the sign. Each message queue has a name and a list of messages. Within each message is where important information such as the sign mode, color, and speed of the message are specified. Variables can also be combined here to show within the same message. The order of the messages is the order they will be sent to the sign.
@@ -554,7 +571,7 @@ The color filter can be used with a template to change the color of a string wit
 {{ 'this will be red or green' | color('red', value > 0, 'green') }}
 ```
 
-
+_Note_: due to some technical limitations with the Alphasign protocol the `rainbow1', 'rainbow2`, and `color_mix` colors can't be set inline and will be set to `green` when using this filter. To get around this set the color on a variable and combine variables in a message. 
 
 #### shorten_urls
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Home Assistant Betabrite Sign
-[![Build Status](https://img.shields.io/github/workflow/status/robweber/ha-betabrite-sign/Python%20Code%20Check)](https://github.com/robweber/ha-betabrite-sign/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/robweber/ha-betabrite-sign/flake8.yml?branch=main)](https://github.com/robweber/ha-betabrite-sign/actions)
 [![License](https://img.shields.io/github/license/robweber/ha-betabrite-sign)](https://github.com/robweber/ha-betabrite-sign/blob/main/LICENSE)
 [![PEP8](https://img.shields.io/badge/code%20style-pep8-orange.svg)](https://www.python.org/dev/peps/pep-0008/)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
@@ -571,7 +571,7 @@ The color filter can be used with a template to change the color of a string wit
 {{ 'this will be red or green' | color('red', value > 0, 'green') }}
 ```
 
-_Note_: due to some technical limitations with the Alphasign protocol the `rainbow1', 'rainbow2`, and `color_mix` colors can't be set inline and will be set to `green` when using this filter. To get around this set the color on a variable and combine variables in a message. 
+_Note_: due to some technical limitations with the Alphasign protocol the `rainbow1', 'rainbow2`, and `color_mix` colors can't be set inline and will be set to `green` when using this filter. To get around this set the color on a variable and combine variables in a message.
 
 #### shorten_urls
 

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -32,7 +32,7 @@ MQTT_ATTRIBUTES = "betabrite/sign/attributes"
 MQTT_SWITCH = "betabrite/sign/switch"
 MQTT_AVAILABLE = "betabrite/sign/available"
 MQTT_COMMAND = "betabrite/sign/command"
-MQTT_DISCOVERY_CLASS = "light"
+MQTT_DISCOVERY_LIGHT_CLASS = "light"
 
 # variable for when the sign is in off mode
 SIGN_OFF = "ALPHA_SIGN_OFF"

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -40,6 +40,9 @@ MQTT_DISCOVERY_TEXT_CLASS = "text"
 # variable for when the sign is in off mode
 SIGN_OFF = "ALPHA_SIGN_OFF"
 
+# text entity MQTT variable name
+TEXT_ENTITY_VARIABLE = "HA_TEXT_ENTITY"
+
 # dicts to transfrom yaml to alphasign variables
 ALPHA_MODES = {"rotate": alphasign.modes.ROTATE, "hold": alphasign.modes.HOLD, "roll_up": alphasign.modes.ROLL_UP,
                "roll_down": alphasign.modes.ROLL_DOWN, "roll_left": alphasign.modes.ROLL_LEFT, "roll_right": alphasign.modes.ROLL_RIGHT,

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -32,7 +32,10 @@ MQTT_ATTRIBUTES = "betabrite/sign/attributes"
 MQTT_SWITCH = "betabrite/sign/switch"
 MQTT_AVAILABLE = "betabrite/sign/available"
 MQTT_COMMAND = "betabrite/sign/command"
+MQTT_CURRENT_TEXT = "betabrite/sign/current_text"
+MQTT_NEW_TEXT = "betabrite/sign/new_text"
 MQTT_DISCOVERY_LIGHT_CLASS = "light"
+MQTT_DISCOVERY_TEXT_CLASS = "text"
 
 # variable for when the sign is in off mode
 SIGN_OFF = "ALPHA_SIGN_OFF"

--- a/lib/manager.py
+++ b/lib/manager.py
@@ -60,6 +60,9 @@ class MessageManager:
         # load all variable objects right away
         self.__load_variables()
 
+        # add a special variable for the MQTT Text Entity
+        self.varObjs[constants.TEXT_ENTITY_VARIABLE] = MQTTVariable(constants.TEXT_ENTITY_VARIABLE, {"topic": constants.MQTT_CURRENT_TEXT})
+
     def __load_variables(self):
         """create VariableType objects from the variables
         key in the yaml file

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ def mqtt_connect(client, userdata, flags, rc):
     logging.info("Connected to MQTT Server")
 
     device_name_slug = slugify(args.ha_device_name, separator='_')
-    discovery_topics = {constants.MQTT_DISCOVERY_LIGHT_CLASS: ""}
+    discovery_topics = {constants.MQTT_DISCOVERY_LIGHT_CLASS: "", constants.MQTT_DISCOVERY_TEXT_CLASS: ""}
     if(args.ha_discovery):
         # generate the light entity config
         discovery_topics[constants.MQTT_DISCOVERY_LIGHT_CLASS] = {"name": args.ha_device_name, "device_class": constants.MQTT_DISCOVERY_LIGHT_CLASS,
@@ -67,6 +67,11 @@ def mqtt_connect(client, userdata, flags, rc):
                                                                   "command_topic": constants.MQTT_SWITCH, "json_attributes_topic": constants.MQTT_ATTRIBUTES,  # noqa
                                                                   "availability_topic": constants.MQTT_AVAILABLE, "qos": 0, "payload_on": "ON",
                                                                   "payload_off": "OFF", "optimistic": False}
+
+        discovery_topics[constants.MQTT_DISCOVERY_TEXT_CLASS] = {"name": f"{args.ha_device_name} Text", "device_class": constants.MQTT_DISCOVERY_TEXT_CLASS,
+                                                                 "object_id": f"{device_name_slug}_text", "unique_id": f"{device_name_slug}_text",
+                                                                 "state_topic": constants.MQTT_CURRENT_TEXT, "command_topic": constants.MQTT_NEW_TEXT,
+                                                                 "availability_topic": constants.MQTT_AVAILABLE, "qos": 0}
 
     for entity_type in discovery_topics:
         topic = f"{args.mqtt_discovery_prefix}/{entity_type}/{device_name_slug}/config"

--- a/main.py
+++ b/main.py
@@ -59,17 +59,17 @@ def mqtt_connect(client, userdata, flags, rc):
     logging.info("Connected to MQTT Server")
 
     device_name_slug = slugify(args.ha_device_name, separator='_')
-    discovery_topic = f"{args.mqtt_discovery_prefix}/{constants.MQTT_DISCOVERY_CLASS}/{device_name_slug}/config"
+    discovery_topic = f"{args.mqtt_discovery_prefix}/{constants.MQTT_DISCOVERY_LIGHT_CLASS}/{device_name_slug}/config"
     if(args.ha_discovery):
-        # generate the entity config
-        entity_config = {"name": args.ha_device_name, "device_class": "light", "object_id": device_name_slug,
+        # generate the light entity config
+        light_entity_config = {"name": args.ha_device_name, "device_class": constants.MQTT_DISCOVERY_LIGHT_CLASS, "object_id": device_name_slug,
                          "unique_id": device_name_slug, "state_topic": constants.MQTT_STATUS, "command_topic": constants.MQTT_SWITCH,
                          "json_attributes_topic": constants.MQTT_ATTRIBUTES, "availability_topic": constants.MQTT_AVAILABLE,
                          "qos": 0, "payload_on": "ON", "payload_off": "OFF", "optimistic": False}
-        logging.debug(f"Configuring HA Entity {discovery_topic}: {json.dumps(entity_config)}")
+        logging.debug(f"Configuring HA Light Entity {discovery_topic}: {json.dumps(light_entity_config)}")
 
         # publish the entity config to the HA discovery prefix
-        mqtt_client.publish(discovery_topic, json.dumps(entity_config), retain=True)
+        mqtt_client.publish(discovery_topic, json.dumps(light_entity_config), retain=True)
     else:
         # publish blank string to delete the device
         mqtt_client.publish(discovery_topic, "", retain=True)

--- a/main.py
+++ b/main.py
@@ -68,7 +68,7 @@ def mqtt_connect(client, userdata, flags, rc):
                                                                   "availability_topic": constants.MQTT_AVAILABLE, "qos": 0, "payload_on": "ON",
                                                                   "payload_off": "OFF", "optimistic": False}
 
-        discovery_topics[constants.MQTT_DISCOVERY_TEXT_CLASS] = {"name": f"{args.ha_device_name} Text", "device_class": constants.MQTT_DISCOVERY_TEXT_CLASS,
+        discovery_topics[constants.MQTT_DISCOVERY_TEXT_CLASS] = {"name": f"{args.ha_device_name} Text", "device_class": constants.MQTT_DISCOVERY_TEXT_CLASS,  # noqa
                                                                  "object_id": f"{device_name_slug}_text", "unique_id": f"{device_name_slug}_text",
                                                                  "state_topic": constants.MQTT_CURRENT_TEXT, "command_topic": constants.MQTT_NEW_TEXT,
                                                                  "availability_topic": constants.MQTT_AVAILABLE, "qos": 0}
@@ -99,6 +99,10 @@ def mqtt_on_message(client, userdata, message):
     elif(message.topic == constants.MQTT_COMMAND):
         # format is {command:"", params: {}}  noqa: E800
         payload = json.loads(message.payload.decode('utf-8'))
+
+    elif(message.topic == constants.MQTT_NEW_TEXT):
+        # republish into state topic
+        mqtt_client.publish(constants.MQTT_CURRENT_TEXT, message.payload, retain=True)
 
     else:
         # this is for a variable, load it
@@ -374,7 +378,7 @@ if(args.mqtt and args.mqtt_username):
     mqtt_client.connect(args.mqtt)
 
     # subscribe to the built in topics
-    watchTopics = [(constants.MQTT_SWITCH, 1), (constants.MQTT_COMMAND, 1)]
+    watchTopics = [(constants.MQTT_SWITCH, 1), (constants.MQTT_COMMAND, 1), (constants.MQTT_NEW_TEXT, 1)]
 
     # get a list of all mqtt variables
     mqttVars = manager.get_variables_by_filter(constants.MQTT_CATEGORY)


### PR DESCRIPTION
This adds support for exposing a [Home Assistant Text Entity](https://www.home-assistant.io/integrations/text/), recently added in the 2022.12 update. This is an entity that integrations can use to send text from Home Assistant to a device. In this case it will expose a custom variable `HA_TEXT_ENTITY` that can be inserted into messages or used as part of templates. Use of this requires enabling HA Discovery as well as having a functional MQTT server setup in Home Assistant. 

Also added a few other bug fixes (see CHANGELOG)